### PR TITLE
[HOTFIX] Changes npm install client packages order

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "migrate": "npm run migrate --prefix api",
     "seed": "npm run seed --prefix api",
     "\n# Client commands": "",
-    "build-client": "npm i --prefix client --only=dev && npm i --prefix client && npm run build --prefix client",
+    "build-client": "npm i --prefix client && npm i --prefix client --only=dev && npm run build --prefix client",
     "client-npm": "docker-compose run --rm site npm",
     "client-test": "npm run test --prefix client",
     "ctw": "npm run client-test",


### PR DESCRIPTION
---
name: Hotfix
about: Issues with Heroku deployment
---

# Tests

- [ ] Added unit tests
- [X] Manually tested areas it could break. (**Heroku only**)

Hello guys, I was using the boilerplate in a [project](https://github.com/victorfeijo/chess95) and had some issues deploying it to Heroku. At my local machine I was able to build it, but when pushing to Heroku I was receiving a error:

```
node-sass@4.12.0 install: `node scripts/install.js` cant find module 'set-blocking`
```

After trying some solutions like installing these modules, changing NodeJS and NPM versions and installing `api` before `client`. I ended-up installing client production dependencies before installing only development and it worked.

Have you guys any idea why this is happening? Let me know if my "workaround" is fine or if we can look for a better approach.
